### PR TITLE
Update to Java 21

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     cloud-config:
-        image: java:8
+        image: eclipse-temurin:21
         volumes:
         - "/e/DinioDinev/Projects/microservice-application/rss-configuration-cloudserver/target:/config/:rw"
         restart: always
@@ -10,7 +10,7 @@ services:
         ports : 
         - 8888:8888
     eureka:
-        image: java:8
+        image: eclipse-temurin:21
         volumes:
         - "/e/DinioDinev/Projects/microservice-application/rss-discovery-server/target:/eureka/:rw"
         restart: always
@@ -21,7 +21,7 @@ services:
         ports : 
         - 8761:8761
     rss-reader:
-        image: java:8
+        image: eclipse-temurin:21
         volumes:
         - "/e/DinioDinev/Projects/microservice-application/rss-reader-service/target/:/rss/:rw"
         - "/e/DinioDinev/Projects/microservice-application/rss-reader-service/src/main/resources/hsql/:/db/:rw"

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <spring-cloud.version>Edgware.SR2</spring-cloud.version>
-    <java.version>1.8</java.version>
+    <java.version>21</java.version>
   </properties>
   
   <modules>


### PR DESCRIPTION
## Summary
- bump the Java version property to 21
- use a Java 21 docker image in `docker-compose.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68831085bcbc83218582b316100e7ea7