### PR TITLE
Fix Travis badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Used technologies:
 - Spring Cloud Config Server
 - Spring Cloud Netflix Eureka
 
-[![Build Status](https://travis-ci.org/diniodinev/microservice-application.svg?branch=master)](https://travis-ci.org/diniodinev/microservice-application)
+[![Build Status](https://travis-ci.com/diniodinev/microservice-application.svg?branch=master)](https://travis-ci.com/diniodinev/microservice-application)
 
 ## Modules
 


### PR DESCRIPTION
## Summary
- update Travis CI badge to use travis-ci.com

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688375f8cad88321a3beb7f7f668fa65