### PR TITLE
Fix HSQL dialect property

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,8 +10,8 @@ logging:
 spring:
   jpa:
     show-sql: false
+    database-platform: org.hibernate.dialect.HSQLDialect
     hibernate:
-      dialect: org.hibernate.dialect.HSQLDialect   # ✅ add this line
       ddl-auto: update
     properties:
       hibernate:


### PR DESCRIPTION
## Summary
- fix HSQL dialect property in application.yml to use `database-platform` property

## Testing
- `./gradlew test --info` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68847875835c8321b987cd7f5eb7d79b